### PR TITLE
Updated Prerequisites.

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -9,6 +9,7 @@
 *   Docker 
 *   Docker Login to all the registries
 *   Kubeconfig at `<user.home>`/.kube/config
+*   Java (jdk 11.0.9.1 and above)
 
 ### Architecture Overview
 

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -9,7 +9,7 @@
 *   Docker 
 *   Docker Login to all the registries
 *   Kubeconfig at `<user.home>`/.kube/config
-*   Java (jdk 11.0.9.1 and above)
+*   Java (jdk 11.0.8 and above)
 
 ### Architecture Overview
 


### PR DESCRIPTION
After adding "maven-javadoc-plugin", the build is failing with an older version of java. So It is recommended to use the Java version above 11.0.8